### PR TITLE
Allow attributes in extended output modes.

### DIFF
--- a/src/demo/output.c
+++ b/src/demo/output.c
@@ -79,7 +79,7 @@ static void draw_all() {
 			x = 0;
 			++y;
 		}
-		tb_change_cell(x, y, '@', c, 0);
+		tb_change_cell(x, y, '+', c | ((y & 1) ? TB_UNDERLINE : 0), 0);
 		tb_change_cell(x+25, y, ' ', 0, c);
 	}
 	tb_present();

--- a/src/termbox.c
+++ b/src/termbox.c
@@ -429,20 +429,20 @@ static void send_attr(uint16_t fg, uint16_t bg)
 
 		switch (outputmode) {
 		case TB_OUTPUT_256:
-			fgcol = (fg > 255) ? 7 : fg;
-			bgcol = (bg > 255) ? 0 : bg;
+			fgcol = fg & 0xFF;
+			bgcol = bg & 0xFF;
 			break;
 
 		case TB_OUTPUT_216:
-			fgcol = (fg > 215) ? 7 : fg;
-			bgcol = (bg > 215) ? 0 : bg;
+			fgcol = fg & 0xFF; if(fgcol > 215) fgcol = 7;
+			bgcol = bg & 0xFF; if(bgcol > 215) bgcol = 0;
 			fgcol += 0x10;
 			bgcol += 0x10;
 			break;
 
 		case TB_OUTPUT_GRAYSCALE:
-			fgcol = (fg > 23) ? 23 : fg;
-			bgcol = (bg > 23) ? 0 : bg;
+			fgcol = fg & 0xFF; if(fg > 23) fg = 23;
+			bgcol = bg & 0xFF; if(bg > 23) bg = 0;
 			fgcol += 0xe8;
 			bgcol += 0xe8;
 			break;
@@ -451,16 +451,16 @@ static void send_attr(uint16_t fg, uint16_t bg)
 		default:
 			fgcol = fg & 0x0F;
 			bgcol = bg & 0x0F;
-
-			if (fg & TB_BOLD)
-				bytebuffer_puts(&output_buffer, funcs[T_BOLD]);
-			if (bg & TB_BOLD)
-				bytebuffer_puts(&output_buffer, funcs[T_BLINK]);
-			if (fg & TB_UNDERLINE)
-				bytebuffer_puts(&output_buffer, funcs[T_UNDERLINE]);
-			if ((fg & TB_REVERSE) || (bg & TB_REVERSE))
-				bytebuffer_puts(&output_buffer, funcs[T_REVERSE]);
 		}
+
+		if (fg & TB_BOLD)
+			bytebuffer_puts(&output_buffer, funcs[T_BOLD]);
+		if (bg & TB_BOLD)
+			bytebuffer_puts(&output_buffer, funcs[T_BLINK]);
+		if (fg & TB_UNDERLINE)
+			bytebuffer_puts(&output_buffer, funcs[T_UNDERLINE]);
+		if ((fg & TB_REVERSE) || (bg & TB_REVERSE))
+			bytebuffer_puts(&output_buffer, funcs[T_REVERSE]);
 
 		switch (outputmode) {
 		case TB_OUTPUT_256:

--- a/src/termbox.h
+++ b/src/termbox.h
@@ -113,9 +113,9 @@ extern "C" {
 // using bitwise OR ('|'). Although, colors cannot be combined. But you can
 // combine attributes and a single color. See also struct tb_cell's fg and bg
 // fields.
-#define TB_BOLD      0x10
-#define TB_UNDERLINE 0x20
-#define TB_REVERSE   0x40
+#define TB_BOLD      0x0100
+#define TB_UNDERLINE 0x0200
+#define TB_REVERSE   0x0400
 
 // A cell, single conceptual entity on the terminal screen. The terminal screen
 // is basically a 2d array of cells. It has the following fields:


### PR DESCRIPTION
Attributes were only working in TB_OUTPUT_NORMAL mode; it's nice to have them in 256 mode also. tb_cell's bg and fg were already stored in shorts, but the high byte wasn't being used.
