### PR TITLE
Well-defined screen geometry before init and after shutdown

### DIFF
--- a/src/termbox.c
+++ b/src/termbox.c
@@ -35,8 +35,8 @@ static struct cellbuf front_buffer;
 static struct bytebuffer output_buffer;
 static struct bytebuffer input_buffer;
 
-static int termw;
-static int termh;
+static int termw = -1;
+static int termh = -1;
 
 static int inputmode = TB_INPUT_ESC;
 static int outputmode = TB_OUTPUT_NORMAL;
@@ -149,6 +149,7 @@ void tb_shutdown(void)
 	cellbuf_free(&front_buffer);
 	bytebuffer_free(&output_buffer);
 	bytebuffer_free(&input_buffer);
+    termw = termh = -1;
 }
 
 void tb_present(void)

--- a/src/termbox.h
+++ b/src/termbox.h
@@ -166,7 +166,9 @@ SO_IMPORT void tb_shutdown(void);
 
 /* Returns the size of the internal back buffer (which is the same as
  * terminal's window size in characters). The internal buffer can be resized
- * after tb_clear() or tb_present() function calls.
+ * after tb_clear() or tb_present() function calls. Both dimensions have an
+ * unspecified negative value when called before tb_init() or after
+ * tb_shutdown().
  */
 SO_IMPORT int tb_width(void);
 SO_IMPORT int tb_height(void);


### PR DESCRIPTION
a) initialize termw and termh to -1.

b) make an API guaranty that the screen dimensions are "negative" (no
need to say -1) if tb_init() has not been called or if tb_shutdown()
has been called without a subsequent tb_init() (i.e., if we're in tb
screen mode).

c) in tb_shutdown(), set termw/termh back to -1.
