### PR TITLE
Workaround for changes in 3.4 CPython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
     url = 'http://code.google.com/p/termbox/',
     license = 'MIT',
     cmdclass = {'build_ext': build_ext},
-    ext_modules = [Extension('termbox', sourcefiles)],
+    ext_modules = [Extension('termbox', sourcefiles, extra_compile_args=["-Wno-error=declaration-after-statement"])],
 )


### PR DESCRIPTION
Build is broken in Python 3.4, because someone had an idea to enforce ISO C90 standard on all C source code. Without manually disabling them compilation breaks pretty easily on the beginning of utf8.c (`int i` in bad place...).
