### PR TITLE
Add a get_ch function

### DIFF
--- a/src/termbox.c
+++ b/src/termbox.c
@@ -205,6 +205,15 @@ void tb_put_cell(int x, int y, const struct tb_cell *cell)
 	CELL(&back_buffer, x, y) = *cell;
 }
 
+uint32_t tb_get_ch(int x, int y)
+{
+	if ((unsigned)x >= (unsigned)back_buffer.width)
+		return 0;
+	if ((unsigned)y >= (unsigned)back_buffer.height)
+		return 0;
+	return CELL(&back_buffer, x, y).ch;
+}
+
 void tb_change_cell(int x, int y, uint32_t ch, uint16_t fg, uint16_t bg)
 {
 	struct tb_cell c = {ch, fg, bg};

--- a/src/termbox.h
+++ b/src/termbox.h
@@ -195,6 +195,7 @@ SO_IMPORT void tb_set_cursor(int cx, int cy);
  */
 SO_IMPORT void tb_put_cell(int x, int y, const struct tb_cell *cell);
 SO_IMPORT void tb_change_cell(int x, int y, uint32_t ch, uint16_t fg, uint16_t bg);
+SO_IMPORT uint32_t tb_get_ch(int x, int y);
 
 /* Copies the buffer from 'cells' at the specified position, assuming the
  * buffer is a two-dimensional array of size ('w' x 'h'), represented as a


### PR DESCRIPTION
This function returns the uint32_t utf8 character value at a particular
cell coordinate in the back buffer.
