### PR TITLE
Fix memory leak in `init_term()`.

### DIFF
--- a/src/term.inl
+++ b/src/term.inl
@@ -273,6 +273,7 @@ static int init_term(void) {
 	}
 
 	init_from_terminfo = true;
+	free(data);
 	return 0;
 }
 


### PR DESCRIPTION
Output of `valgrind --leak-check=full build/src/demo/keyboard` and pressing a few keys:

Before:

```
==86608== HEAP SUMMARY:
==86608==     in use at exit: 29,236 bytes in 377 blocks
==86608==   total heap usage: 492 allocs, 115 frees, 138,145 bytes allocated
==86608==
==86608== 3,322 bytes in 1 blocks are definitely lost in loss record 78 of 78
==86608==    at 0x66BB: malloc (in /usr/local/Cellar/valgrind/3.10.1/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==86608==    by 0x10664: read_file (in /Users/.../termbox/build/src/libtermbox.dylib)
==86608==    by 0x105A5: terminfo_try_path (in /Users/.../termbox/build/src/libtermbox.dylib)
==86608==    by 0x10111: load_terminfo (in /Users/.../termbox/build/src/libtermbox.dylib)
==86608==    by 0xDA9C: init_term (in /Users/.../termbox/build/src/libtermbox.dylib)
==86608==    by 0xD802: tb_init (in /Users/.../termbox/build/src/libtermbox.dylib)
==86608==    by 0x100001A3A: main (in build/src/demo/keyboard)
==86608==
==86608== LEAK SUMMARY:
==86608==    definitely lost: 3,322 bytes in 1 blocks
==86608==    indirectly lost: 0 bytes in 0 blocks
==86608==      possibly lost: 0 bytes in 0 blocks
==86608==    still reachable: 0 bytes in 0 blocks
==86608==         suppressed: 25,914 bytes in 376 blocks
==86608==
==86608== For counts of detected and suppressed errors, rerun with: -v
==86608== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 17 from 17)
```

After:

```

==86465== HEAP SUMMARY:
==86465==     in use at exit: 25,914 bytes in 376 blocks
==86465==   total heap usage: 492 allocs, 116 frees, 138,145 bytes allocated
==86465==
==86465== LEAK SUMMARY:
==86465==    definitely lost: 0 bytes in 0 blocks
==86465==    indirectly lost: 0 bytes in 0 blocks
==86465==      possibly lost: 0 bytes in 0 blocks
==86465==    still reachable: 0 bytes in 0 blocks
==86465==         suppressed: 25,914 bytes in 376 blocks
==86465==
==86465== For counts of detected and suppressed errors, rerun with: -v
==86465== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 17 from 17)
```

Note that I'm not 100% sure if this patch is correct. :)