### PR TITLE
Handle NUL code point in tb_utf8_unicode_to_char.

### DIFF
--- a/src/utf8.c
+++ b/src/utf8.c
@@ -49,7 +49,10 @@ int tb_utf8_unicode_to_char(char *out, uint32_t c)
 	int first;
 	int i;
 
-	if (c < 0x80) {
+	if (c == 0) {
+		first = 0;
+		len = 0;
+	} else if (c < 0x80) {
 		first = 0;
 		len = 1;
 	} else if (c < 0x800) {


### PR DESCRIPTION
This is a bit semantic, but assuming the return value of `tb_utf8_unicode_to_char` is supposed to represent the length (as in strlen) of the resulting UTF-8 string `out`, a NUL code point should result in a 0-length string, not 1-length.