### PR TITLE
Port wide char display from termbox-go

### DIFF
--- a/wscript
+++ b/wscript
@@ -20,7 +20,7 @@ def configure(conf):
 	conf.env.VERSION = VERSION
 	conf.load('gnu_dirs')
 	conf.load('compiler_c')
-	conf.env.append_unique('CFLAGS', ['-std=gnu99', '-Wall', '-Wextra'])
+	conf.env.append_unique('CFLAGS', ['-std=gnu99', '-Wall', '-Wextra', '-D_XOPEN_SOURCE'])
 	if conf.options.debug:
 		conf.env.append_unique('CFLAGS', ['-g', '-Og'])
 	else:


### PR DESCRIPTION
Similar logic to what's done in termbox-go, but also handles chars with wcwidth>2 if those exist.

Note `_XOPEN_SOURCE` has to be defined to make `wcwidth` available. Also note `wcwidth` relies on locale, so users will probably want to call `setlocale(LC_ALL, "")` before `tb_init`.
