### PR TITLE
Handle full read buffer in read_up_to.

### DIFF
--- a/src/termbox.c
+++ b/src/termbox.c
@@ -598,8 +598,11 @@ static int read_up_to(int n) {
 	bytebuffer_resize(&input_buffer, prevlen + n);
 
 	int read_n = 0;
-	while (read_n < n) {
-		ssize_t r = read(inout,	input_buffer.buf + prevlen + read_n, n - read_n);
+	while (read_n <= n) {
+		ssize_t r = 0;
+		if (read_n < n) {
+			r = read(inout, input_buffer.buf + prevlen + read_n, n - read_n);
+		}
 #ifdef __CYGWIN__
 		// While linux man for tty says when VMIN == 0 && VTIME == 0, read
 		// should return 0 when there is nothing to read, cygwin's read returns


### PR DESCRIPTION
This avoids `assert(!"unreachable");` in the case where we try to read `n=ENOUGH_DATA_FOR_PARSING` bytes and get all `n` in one read. I noticed this while pasting a large chunk of text into a program blocked on `tb_poll_event`.