### PR TITLE
supporting clibs package manager (by adding package.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "src": [
     "src/bytebuffer.inl",
     "src/input.inl",
-    "term.inl",
-    "termbox.c",
-    "termbox.h",
-    "utf8.c"
+    "src/term.inl",
+    "src/termbox.c",
+    "src/termbox.h",
+    "src/utf8.c"
    ]
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "termbox",
+  "version": "1.0.1a1",
+  "repo": "nsf/termbox",
+  "description": "Library for writing text-based user interfaces",
+  "keywords": [
+    "termbox",
+    "terminal",
+    "term",
+    "tty",
+    "ansi",
+    "escape",
+    "colors",
+    "console"
+  ],
+  "license": "MIT",
+  "src": [
+    "src/bytebuffer.inl",
+    "src/input.inl",
+    "term.inl",
+    "termbox.c",
+    "termbox.h",
+    "utf8.c"
+   ]
+}


### PR DESCRIPTION
Termbox is really cool, and clibs are too, so they belong together :)
more info on clibs here https://github.com/clibs/clib

with this change, people who want to play with termbox will just have to enter in command line

    $ clibs install nsf/termbox

And now all the required files for termbox are in deps/termbox/ (the *.inl and *.c for termbox/src)

Once again, thank you for termbox.

PS. 
For clibs search termbox to work propertly, update to this wiki page is needed
https://github.com/clibs/clib/wiki/Packages
