### PR TITLE
Added 'void' to 'tb_cell_buffer' parameter list

### DIFF
--- a/src/termbox.c
+++ b/src/termbox.c
@@ -270,7 +270,7 @@ void tb_blit(int x, int y, int w, int h, const struct tb_cell *cells)
 	}
 }
 
-struct tb_cell *tb_cell_buffer()
+struct tb_cell *tb_cell_buffer(void)
 {
 	return back_buffer.cells;
 }

--- a/src/termbox.h
+++ b/src/termbox.h
@@ -221,7 +221,7 @@ SO_IMPORT void tb_blit(int x, int y, int w, int h, const struct tb_cell *cells);
  * as no tb_clear() and tb_present() calls are made. The buffer is
  * one-dimensional buffer containing lines of cells starting from the top.
  */
-SO_IMPORT struct tb_cell *tb_cell_buffer();
+SO_IMPORT struct tb_cell *tb_cell_buffer(void);
 
 #define TB_INPUT_CURRENT 0 /* 000 */
 #define TB_INPUT_ESC     1 /* 001 */


### PR DESCRIPTION
The lack of an explicit void in C implies an unknown number of parameters rather than none. This simply adds the explicit void.

Note that without this the following compiles without warning or error:
```c
#include <termbox.h>

int main() {
    tb_cell_buffer(12);
    return 0;
}
```