### PR TITLE
Add a link to Common Lisp wrapper.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,7 @@ LINKS
 - http://pecl.php.net/package/termbox - PHP Termbox wrapper
 - https://github.com/nsf/termbox-go - Go pure Termbox implementation
 - https://github.com/gchp/rustbox - Rust Termbox wrapper
+- https://github.com/fouric/cl-termbox - Common Lisp Termbox wrapper
 
 ----
 


### PR DESCRIPTION
Tiny change to README to add a link to a Common Lisp wrapper.