### PR TITLE
Void argc and argv in paint demo

### DIFF
--- a/src/demo/paint.c
+++ b/src/demo/paint.c
@@ -98,6 +98,7 @@ void reallocBackBuffer(int w, int h) {
 }
 
 int main(int argv, char **argc) {
+	(void)argc; (void)argv;
 	int code = tb_init();
 	if (code < 0) {
 		fprintf(stderr, "termbox init failed, code: %d\n", code);


### PR DESCRIPTION
In line with other demo examples, silences compiler warning.