### PR TITLE
Add tb_poll_fds() to obtain file descriptors for polling

### DIFF
--- a/src/termbox.c
+++ b/src/termbox.c
@@ -296,6 +296,19 @@ int tb_peek_event(struct tb_event *event, int timeout)
 	return wait_fill_event(event, &tv);
 }
 
+size_t tb_poll_fds(int *fds, size_t fds_size)
+{
+	if (fds != NULL) {
+		if (fds_size >= 1) {
+			fds[0] = inout;
+		}
+		if (fds_size >= 2) {
+			fds[1] = winch_fds[0];
+		}
+	}
+	return 2;
+}
+
 int tb_width(void)
 {
 	return termw;

--- a/src/termbox.h
+++ b/src/termbox.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h>
 
 /* for shared objects */
 #if __GNUC__ >= 4
@@ -308,6 +309,15 @@ SO_IMPORT int tb_peek_event(struct tb_event *event, int timeout);
  * constants) or -1 if there was an error.
  */
 SO_IMPORT int tb_poll_event(struct tb_event *event);
+
+
+/* Obtains a list of internal file descriptors which can be watched for events.
+ * This can be used to integrate termbox into fd-based event loops.
+ * If fds is not NULL, up to fds_size file descriptors are stored there.
+ * Returns the number of available file descriptors, which
+ * may be more or less than fds_size.
+*/
+SO_IMPORT size_t tb_poll_fds(int *fds, size_t fds_size);
 
 /* Utility utf8 functions. */
 #define TB_EOF -1


### PR DESCRIPTION
This adds a function to obtain file descriptors from termbox that can be be polled for IO-readiness.
This can be used to integrate termbox into an event loop like asyncio or curio in python, or libuv in C, so the program can process other things (like network sockets) asynchronously with UI events.

The idea is to use `tb_poll_fds()` to get a set of descriptors, register them for polling (e.g. with `EPOLLIN`), and when any events arrive, the next `tb_poll_event()` can be expected to complete quickly.

(edit: markdown formatting and C usage example)