### PR TITLE
README: add link to Nim bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ a note via email, you can find my email below.
 - https://github.com/andrewsuzuki/termbox-crystal - Crystal
 - https://github.com/jgoldfar/Termbox.jl - Julia
 - https://github.com/mitchellwrosen/termbox - Haskell
+- https://github.com/dom96/nimbox - Nim
 
 ##### Other implementations
 


### PR DESCRIPTION
I've been using @dom96's Nim bindings for termbox for some months now. They work well, and so I thought it would be nice to have them added to the list, so that others could easily find them.