### PR TITLE
Adds my own Termbox application/framework to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ a note via email, you can find my email below.
 ##### Applications
 
 - https://github.com/adsr/mle - a small, flexible terminal-based text editor
+- https://github.com/colinta/Ashen - framework for building terminal applications based on the Elm architecture
 
 ### Bugs & questions
 


### PR DESCRIPTION
I'm using Termbox in my application framework – via dduan's Swift wrapper.