### PR TITLE
Interpret TERM=tmux as TERM=screen.

### DIFF
--- a/src/term.inl
+++ b/src/term.inl
@@ -124,6 +124,8 @@ static int init_term_builtin(void)
 			return 0;
 		if (try_compatible(term, "screen", screen_keys, screen_funcs) == 0)
 			return 0;
+		if (try_compatible(term, "tmux", screen_keys, screen_funcs) == 0)
+			return 0;
 		/* let's assume that 'cygwin' is xterm compatible */
 		if (try_compatible(term, "cygwin", xterm_keys, xterm_funcs) == 0)
 			return 0;


### PR DESCRIPTION
Old versions of tmux required TERM=screen. New versions say TERM=tmux
is ok too. Patch seems to work as expected with mle.